### PR TITLE
[RSDK-10180] - add validation for default camera behavior

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -35,7 +35,7 @@ class ToChannelsLast:
 # pylint: disable=too-few-public-methods
 class Preprocessor:
     """Main wrapper class that performs a series of preprocessing steps"""
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         weights_transform=None,

--- a/src/torchvision_module.py
+++ b/src/torchvision_module.py
@@ -189,6 +189,14 @@ class TorchVisionService(Vision, Reconfigurable):
             classifications, and objects, as well as any extra info the model may provide.
         """
         result = CaptureAllResult()
+
+        if camera_name not in (self.camera_name, ""):
+            raise ValueError(
+                "Camera name passed to method:",
+                camera_name,
+                "is not the configured 'camera_name'",
+                self.camera_name,
+            )
         image = await self.get_image_from_dependency(camera_name)
 
         if return_image:
@@ -271,6 +279,13 @@ class TorchVisionService(Vision, Reconfigurable):
         if not self.properties.implements_classification:
             raise NotImplementedError
 
+        if camera_name not in (self.camera_name, ""):
+            raise ValueError(
+                "Camera name passed to method:",
+                camera_name,
+                "is not the configured 'camera_name'",
+                self.camera_name,
+            )
         image = await self.get_image_from_dependency(camera_name)
         input_tensor = self.preprocessor(image)
         with torch.no_grad():
@@ -278,11 +293,18 @@ class TorchVisionService(Vision, Reconfigurable):
         return self.wrap_classifications(prediction, count)
 
     async def get_detections_from_camera(
-        self, camera_name: str, *, extra: Mapping[str, Any], timeout: float
+        self, camera_name: str, *, extra: Mapping[str, Any] = None, timeout: float = None,
     ) -> List[Detection]:
         """Gets detections from a camera dependency"""
         if not self.properties.implements_detection:
             raise NotImplementedError
+        if camera_name not in (self.camera_name, ""):
+            raise ValueError(
+                "Camera name passed to method:",
+                camera_name,
+                "is not the configured 'camera_name'",
+                self.camera_name,
+            )
         image = await self.get_image_from_dependency(camera_name)
         LOGGER.info(f"input image is: {type(image)}")
         input_tensor = self.preprocessor(image)

--- a/src/torchvision_module.py
+++ b/src/torchvision_module.py
@@ -142,7 +142,7 @@ class TorchVisionService(Vision, Reconfigurable):
         self.default_minimum_confidence = get_attribute_from_config(
             "default_minimum_confidence", 0
         )
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-arguments,too-many-positional-arguments
     async def capture_all_from_camera(
         self,
         camera_name: str,


### PR DESCRIPTION
## Changes
- [x] add validation for camera_name, including allowing empty name in the methods
- [x] test default camera behavior
- [x] bandaid pylint errors caused by package upgrade   